### PR TITLE
Use os-specific temp directory for vscode-port

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -4,6 +4,8 @@ import * as vscode from "vscode";
 import * as http from "http";
 import { AddressInfo } from "net";
 import { writeFileSync } from "fs";
+import { tmpdir } from "os";
+import { join } from "path";
 
 interface Command {
   commandId: string;
@@ -63,7 +65,8 @@ export function activate(context: vscode.ExtensionContext) {
   });
 
   function writePort() {
-    writeFileSync("/tmp/vscode-port", `${port}`);
+    var path = join(tmpdir(), "vscode-port");
+    writeFileSync(path, `${port}`);
   }
 }
 

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -65,7 +65,7 @@ export function activate(context: vscode.ExtensionContext) {
   });
 
   function writePort() {
-    var path = join(tmpdir(), "vscode-port");
+    const path = join(tmpdir(), "vscode-port");
     writeFileSync(path, `${port}`);
   }
 }


### PR DESCRIPTION
This is mostly for Windows support. Tested on both, seems to work fine.

Corresponding python change since I can't fork a fork of my repo hehe:

```
import os
import tempfile

with open(os.path.join(tempfile.gettempdir(), "vscode-port"), "r") as port_file:
```