### PR TITLE
Adds partial support for untrusted workspaces

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,6 +22,16 @@
 	"extensionKind": [
 		"ui"
 	],
+	"capabilities": {
+		"untrustedWorkspaces": {
+			"supported": "limited",
+			"description": "Untrusted workspaces can't override allowList / denyList",
+			"restrictedConfigurations": [
+				"allowList",
+				"denyList"
+			]
+		}
+	},
 	"contributes": {
 		"commands": [
 			{


### PR DESCRIPTION
The only vulnerability I see is the ability for workspaces to override `allowList` and `denyList`.  This extension doesn't try to execute any code in the workspace.