### PR TITLE
Contributed commands to get and set vscode settings

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
 		"type": "git",
 		"url": "https://github.com/pokey/command-server"
 	},
-	"version": "0.8.2",
+	"version": "0.9.0",
 	"engines": {
 		"vscode": "^1.53.0"
 	},
@@ -37,6 +37,14 @@
 			{
 				"command": "command-server.runCommand",
 				"title": "Read command description from a file and execute the command"
+			},
+			{
+				"command": "command-server.getSetting",
+				"title": "Fetch setting from vscode"
+			},
+			{
+				"command": "command-server.setSetting",
+				"title": "Updates setting to vscode"
 			}
 		],
 		"keybindings": [

--- a/src/commandRunner.ts
+++ b/src/commandRunner.ts
@@ -100,7 +100,7 @@ export default class CommandRunner {
         returnValue: commandReturnValue,
         warnings,
       });
-    } catch (err) {
+    } catch (err: any) {
       await writeResponse(responseFile, {
         error: err.message,
         uuid,

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -13,6 +13,16 @@ export function activate(context: vscode.ExtensionContext) {
     vscode.commands.registerCommand(
       "command-server.runCommand",
       commandRunner.runCommand
+    ),
+    vscode.commands.registerCommand(
+      "command-server.getSetting",
+      (section: string, defaultValue?: any) =>
+        vscode.workspace.getConfiguration().get(section, defaultValue)
+    ),
+    vscode.commands.registerCommand(
+      "command-server.setSetting",
+      (section: string, value: any) =>
+        vscode.workspace.getConfiguration().update(section, value, true)
     )
   );
 


### PR DESCRIPTION
```
test get:
    value = user.vscode_get("command-server.getSetting", "cursorless.pendingEditDecorationTime")
    print(value)

test update:
    user.vscode_with_plugin("command-server.setSetting", "cursorless.pendingEditDecorationTime", 100)
```

I suggest that we make python wrapper functions talon side for these
```
test get:
    value = user.vscode_get_setting("cursorless.pendingEditDecorationTime")
    print(value)

test update:
    user.vscode_set_setting("cursorless.pendingEditDecorationTime", 100)
```

