### PR TITLE
Added focused element type

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -8,6 +8,7 @@
     },
     // Turn off tsc task auto detection since we have the necessary tasks as npm scripts
     "typescript.tsc.autoDetect": "off",
+    "prettier.tabWidth": 2,
     "cSpell.words": [
         "eqeqeq"
     ]

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -8,7 +8,6 @@
     },
     // Turn off tsc task auto detection since we have the necessary tasks as npm scripts
     "typescript.tsc.autoDetect": "off",
-    "prettier.tabWidth": 2,
     "cSpell.words": [
         "eqeqeq"
     ]

--- a/package.json
+++ b/package.json
@@ -37,6 +37,10 @@
 			{
 				"command": "command-server.runCommand",
 				"title": "Read command description from a file and execute the command"
+			},
+			{
+				"command": "command-server.getFocusedElementType",
+				"title": "Returns the type of the currently focused element in vscode"
 			}
 		],
 		"keybindings": [

--- a/package.json
+++ b/package.json
@@ -49,6 +49,34 @@
 				"command": "command-server.runCommand",
 				"key": "ctrl+shift+alt+p",
 				"mac": "cmd+shift+alt+p"
+			},
+			{
+				"command": "command-server.runCommand",
+				"key": "ctrl+shift+f17",
+				"mac": "cmd+shift+f17",
+				"when": "editorTextFocus",
+				"args": "textEditor"
+			},
+			{
+				"command": "command-server.runCommand",
+				"key": "ctrl+shift+alt+p",
+				"mac": "cmd+shift+alt+p",
+				"when": "editorTextFocus",
+				"args": "textEditor"
+			},
+			{
+				"command": "command-server.runCommand",
+				"key": "ctrl+shift+f17",
+				"mac": "cmd+shift+f17",
+				"when": "terminalFocus",
+				"args": "terminal"
+			},
+			{
+				"command": "command-server.runCommand",
+				"key": "ctrl+shift+alt+p",
+				"mac": "cmd+shift+alt+p",
+				"when": "terminalFocus",
+				"args": "terminal"
 			}
 		],
 		"configuration": {

--- a/src/commandRunner.ts
+++ b/src/commandRunner.ts
@@ -100,9 +100,9 @@ export default class CommandRunner {
         returnValue: commandReturnValue,
         warnings,
       });
-    } catch (err: any) {
+    } catch (err) {
       await writeResponse(responseFile, {
-        error: err.message,
+        error: (err as Error).message,
         uuid,
         warnings,
       });

--- a/src/commandRunner.ts
+++ b/src/commandRunner.ts
@@ -5,12 +5,13 @@ import * as vscode from "vscode";
 import { readRequest, writeResponse } from "./io";
 import { getResponsePath } from "./paths";
 import { any } from "./regex";
-import { Request, Response } from "./types";
+import { Request, FocusedElementType } from "./types";
 
 export default class CommandRunner {
   allowRegex!: RegExp;
   denyRegex!: RegExp | null;
   backgroundWindowProtection!: boolean;
+  focusedElementType?: FocusedElementType;
 
   constructor() {
     this.reloadConfiguration = this.reloadConfiguration.bind(this);
@@ -50,10 +51,11 @@ export default class CommandRunner {
    * output to response file.  See also documentation for Request / Response
    * types.
    */
-  async runCommand() {
+  async runCommand(focusedElementType?: FocusedElementType) {
+    this.focusedElementType = focusedElementType;
     const responseFile = await open(getResponsePath(), "wx");
 
-    var request: Request;
+    let request: Request;
 
     try {
       request = await readRequest();
@@ -86,7 +88,7 @@ export default class CommandRunner {
 
       const commandPromise = vscode.commands.executeCommand(commandId, ...args);
 
-      var commandReturnValue = null;
+      let commandReturnValue = null;
 
       if (returnCommandOutput) {
         commandReturnValue = await commandPromise;
@@ -100,7 +102,7 @@ export default class CommandRunner {
         returnValue: commandReturnValue,
         warnings,
       });
-    } catch (err) {
+    } catch (err: any) {
       await writeResponse(responseFile, {
         error: err.message,
         uuid,

--- a/src/commandRunner.ts
+++ b/src/commandRunner.ts
@@ -5,13 +5,12 @@ import * as vscode from "vscode";
 import { readRequest, writeResponse } from "./io";
 import { getResponsePath } from "./paths";
 import { any } from "./regex";
-import { Request, FocusedElementType } from "./types";
+import { Request } from "./types";
 
 export default class CommandRunner {
   allowRegex!: RegExp;
   denyRegex!: RegExp | null;
   backgroundWindowProtection!: boolean;
-  focusedElementType?: FocusedElementType;
 
   constructor() {
     this.reloadConfiguration = this.reloadConfiguration.bind(this);
@@ -51,8 +50,7 @@ export default class CommandRunner {
    * output to response file.  See also documentation for Request / Response
    * types.
    */
-  async runCommand(focusedElementType?: FocusedElementType) {
-    this.focusedElementType = focusedElementType;
+  async runCommand() {
     const responseFile = await open(getResponsePath(), "wx");
 
     let request: Request;

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -18,7 +18,7 @@ export function activate(context: vscode.ExtensionContext) {
 
   return {
     /**
-     * The type of the focused element in vscode.
+     * The type of the focused element in vscode at the moment of the command being executed.
      */
     focusedElementType: () => commandRunner.focusedElementType,
 

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -29,7 +29,7 @@ export function activate(context: vscode.ExtensionContext) {
     /**
      * The type of the focused element in vscode at the moment of the command being executed.
      */
-    focusedElementType: () => focusedElementType,
+    getFocusedElementType: () => focusedElementType,
 
     /**
      * These signals can be used as a form of IPC to indicate that an event has

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -1,22 +1,27 @@
 import * as vscode from "vscode";
 
-import { initializeCommunicationDir } from "./initializeCommunicationDir";
 import CommandRunner from "./commandRunner";
+import { initializeCommunicationDir } from "./initializeCommunicationDir";
 import { getInboundSignal } from "./signal";
+import { FocusedElementType } from "./types";
 
 export function activate(context: vscode.ExtensionContext) {
   initializeCommunicationDir();
 
   const commandRunner = new CommandRunner();
+  let focusedElementType: FocusedElementType | undefined;
 
   context.subscriptions.push(
     vscode.commands.registerCommand(
       "command-server.runCommand",
-      commandRunner.runCommand
+      (focusedElementType_?: FocusedElementType) => {
+        focusedElementType = focusedElementType_;
+        return commandRunner.runCommand();
+      }
     ),
     vscode.commands.registerCommand(
       "command-server.getFocusedElementType",
-      () => commandRunner.focusedElementType ?? null
+      () => focusedElementType ?? null
     )
   );
 
@@ -24,7 +29,7 @@ export function activate(context: vscode.ExtensionContext) {
     /**
      * The type of the focused element in vscode at the moment of the command being executed.
      */
-    focusedElementType: () => commandRunner.focusedElementType,
+    focusedElementType: () => focusedElementType,
 
     /**
      * These signals can be used as a form of IPC to indicate that an event has

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -18,6 +18,11 @@ export function activate(context: vscode.ExtensionContext) {
 
   return {
     /**
+     * The type of the focused element in vscode.
+     */
+    focusedElementType: () => commandRunner.focusedElementType,
+
+    /**
      * These signals can be used as a form of IPC to indicate that an event has
      * occurred.
      */

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -13,6 +13,10 @@ export function activate(context: vscode.ExtensionContext) {
     vscode.commands.registerCommand(
       "command-server.runCommand",
       commandRunner.runCommand
+    ),
+    vscode.commands.registerCommand(
+      "command-server.getFocusedElementType",
+      () => commandRunner.focusedElementType ?? null
     )
   );
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -53,6 +53,6 @@ export interface Response {
 }
 
 /**
- * Indicates the type of the focused element in vscode at the moment of the command being executed
+ * The type of the focused element in vscode at the moment of the command being executed.
  */
 export type FocusedElementType = "textEditor" | "terminal";

--- a/src/types.ts
+++ b/src/types.ts
@@ -51,3 +51,8 @@ export interface Response {
    */
   warnings: string[];
 }
+
+/**
+ * Indicates the type of the focused element in vscode at the moment of the command being executed
+ */
+export type FocusedElementType = "textEditor" | "terminal";


### PR DESCRIPTION
Extension now returns the focused element type. Currently limited to text editor, terminal or undefined. 
Added new command `command-server.getFocusedElementType`
