### PR TITLE
Fix Cursorless keyboard broken by focused elements

### DIFF
--- a/package.json
+++ b/package.json
@@ -47,12 +47,14 @@
       {
         "command": "command-server.runCommand",
         "key": "ctrl+shift+f17",
-        "mac": "cmd+shift+f17"
+        "mac": "cmd+shift+f17",
+        "args": "other"
       },
       {
         "command": "command-server.runCommand",
         "key": "ctrl+shift+alt+p",
-        "mac": "cmd+shift+alt+p"
+        "mac": "cmd+shift+alt+p",
+        "args": "other"
       },
       {
         "command": "command-server.runCommand",

--- a/src/commandRunner.ts
+++ b/src/commandRunner.ts
@@ -65,6 +65,8 @@ export default class CommandRunner {
 
     const warnings = [];
 
+    let commandPromise: Thenable<unknown> | undefined;
+
     try {
       if (!vscode.window.state.focused) {
         if (this.backgroundWindowProtection) {
@@ -82,7 +84,7 @@ export default class CommandRunner {
         throw new Error("Command in denyList");
       }
 
-      const commandPromise = vscode.commands.executeCommand(commandId, ...args);
+      commandPromise = vscode.commands.executeCommand(commandId, ...args);
 
       let commandReturnValue = null;
 
@@ -107,5 +109,9 @@ export default class CommandRunner {
     }
 
     await this.io.closeResponse();
+
+    if (commandPromise != null) {
+      await commandPromise;
+    }
   }
 }

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -14,14 +14,15 @@ export async function activate(context: vscode.ExtensionContext) {
   context.subscriptions.push(
     vscode.commands.registerCommand(
       "command-server.runCommand",
-      (focusedElementType_?: FocusedElementType) => {
+      async (focusedElementType_: FocusedElementType) => {
         focusedElementType = focusedElementType_;
-        return commandRunner.runCommand();
+        await commandRunner.runCommand();
+        focusedElementType = undefined;
       }
     ),
     vscode.commands.registerCommand(
       "command-server.getFocusedElementType",
-      () => focusedElementType ?? null
+      () => focusedElementType
     )
   );
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -55,4 +55,4 @@ export interface Response {
 /**
  * The type of the focused element in vscode at the moment of the command being executed.
  */
-export type FocusedElementType = "textEditor" | "terminal";
+export type FocusedElementType = "textEditor" | "terminal" | "other";


### PR DESCRIPTION
Reset focused element to `undefined` after running command so that we don't end up with stale focused element if user runs command outside of command server

- See also https://github.com/cursorless-dev/cursorless/pull/2309