### PR TITLE
Don't wait twice for command promise

### DIFF
--- a/src/commandRunner.ts
+++ b/src/commandRunner.ts
@@ -106,8 +106,13 @@ export default class CommandRunner {
         uuid,
         warnings,
       });
+      commandPromise = undefined;
     }
 
     await this.io.closeResponse();
+
+    if (commandPromise != null) {
+        await commandPromise;
+    }
   }
 }

--- a/src/commandRunner.ts
+++ b/src/commandRunner.ts
@@ -109,9 +109,5 @@ export default class CommandRunner {
     }
 
     await this.io.closeResponse();
-
-    if (commandPromise != null) {
-      await commandPromise;
-    }
   }
 }

--- a/src/commandRunner.ts
+++ b/src/commandRunner.ts
@@ -112,7 +112,7 @@ export default class CommandRunner {
     await this.io.closeResponse();
 
     if (commandPromise != null) {
-        await commandPromise;
+      await commandPromise;
     }
   }
 }


### PR DESCRIPTION
We are already waiting for the command promise online 91 so we don't need to wait for it again. This had the side effect that if the promise was rejected we had an uncaught exception being thrown.

This is the reason why you get two error messages from cursorless. The warning is actually from the command client.

![image](https://github.com/user-attachments/assets/c62f5912-af6d-4a0f-8109-3afbbee545ae)

