### PR TITLE
Use activation event onStartupFinished

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
     "Other"
   ],
   "activationEvents": [
-    "*"
+    "onStartupFinished"
   ],
   "main": "./out/extension.js",
   "extensionKind": [


### PR DESCRIPTION
Startup event `*` makes vscode start slower. `onStartupFinished` is the recommender startup event that will run as soon as vscodes internals have started.