### PR TITLE
Skip command `command-server.runCommand` in terminal

### DIFF
--- a/package.json
+++ b/package.json
@@ -85,6 +85,11 @@
         "args": "terminal"
       }
     ],
+    "configurationDefaults": {
+      "terminal.integrated.commandsToSkipShell": [
+        "command-server.runCommand"
+      ]
+    },
     "configuration": {
       "title": "Command server",
       "properties": {


### PR DESCRIPTION
Added default configuration for setting `terminal.integrated.commandsToSkipShell`

Fixes #14