### PR TITLE
Make trigger shortcut more obscure

### DIFF
--- a/package.json
+++ b/package.json
@@ -52,8 +52,8 @@
       },
       {
         "command": "command-server.runCommand",
-        "key": "ctrl+shift+alt+p",
-        "mac": "cmd+shift+alt+p",
+        "key": "ctrl+shift+alt+meta+`",
+        "mac": "cmd+shift+alt+option+`",
         "args": "other"
       },
       {
@@ -65,8 +65,8 @@
       },
       {
         "command": "command-server.runCommand",
-        "key": "ctrl+shift+alt+p",
-        "mac": "cmd+shift+alt+p",
+        "key": "ctrl+shift+alt+meta+`",
+        "mac": "cmd+shift+alt+option+`",
         "when": "editorTextFocus",
         "args": "textEditor"
       },
@@ -79,8 +79,8 @@
       },
       {
         "command": "command-server.runCommand",
-        "key": "ctrl+shift+alt+p",
-        "mac": "cmd+shift+alt+p",
+        "key": "ctrl+shift+alt+meta+`",
+        "mac": "cmd+shift+alt+option+`",
         "when": "terminalFocus",
         "args": "terminal"
       }


### PR DESCRIPTION
The current shortcut [clashes with some extensions](https://github.com/cursorless-dev/cursorless/issues/880#issuecomment-2606151500)

This seems to work on my linux configuration with codium, whereas the f17 mapping didn't